### PR TITLE
Specify section [global]

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,3 +1,4 @@
+[global]
 frame_color = "#{{base05-hex}}"
 separator_color = "#{{base05-hex}}"
 


### PR DESCRIPTION
Dunst supports storing 'drop-in' config files in `~/.config/dunst/dunstrc.d/*.conf` instead of directly in `~/.config/dunst/dunstrc`. Since this template only specifies colours, it makes sense to store it there instead of the main `dunstrc`. Using the template as-is, however, throws an error:
```
WARNING: Invalid config file at line 1: Key value pair without a section.
WARNING: Invalid config file at line 2: Key value pair without a section.
```
This is simply fixed by specifying that the first two lines belong to the `[global]` section, which is what this PR does.
This should not break anything for users who use the template as the whole of their `dunstrc`.