### PR TITLE
Use base16-builder-go to automatically generate colorschemes

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,25 @@
+name: Update with the latest colorschemes
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # https://crontab.guru/every-week
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch the repository code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
+      - name: Update schemes
+        uses: tinted-theming/base16-builder-go@latest
+      - name: Commit the changes, if any
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update with the latest tinted-theming colorschemes
+          branch: ${{ github.head_ref }}
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+schemes

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To use, you can copy one of the config files in themes/ or use curl:
 
 ```
 mkdir -p ~/.config/dunst
-curl https://raw.githubusercontent.com/tinted-theming/base16-dunst/master/themes/base16-default-dark.dunstrc >> ~/.config/dunst/dunstrc
+curl https://raw.githubusercontent.com/tinted-theming/base16-dunst/main/themes/base16-default-dark.dunstrc >> ~/.config/dunst/dunstrc
 ```
 
 We used `msg_urgency` configuration instead of `urgency_low`, `urgency_normal`,


### PR DESCRIPTION
- Add feature where base16-builder-go is automatically run by a github action once a week to generate the colorschemes.
- Add codeowners file to automatically tag base16-termite maintainers when a PR or issue is created (currently that's only you :smiley:)