### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tinted-theming/dunst

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Kevin Hamer
+Copyright (c) 2022 Tinted Theming
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # base16-dunst
 
 This repository is meant to work with
-[chriskempson/base16](https://github.com/chriskempson/base16).
+[tinted-theming/home](https://github.com/tinted-theming/home).
 It provides a simple template that can be used with the base16 color schemes to
 generate a functional config file for
 [knopwob/dunst](https://github.com/knopwob/dunst),
@@ -11,7 +11,7 @@ To use, you can copy one of the config files in themes/ or use curl:
 
 ```
 mkdir -p ~/.config/dunst
-curl https://raw.githubusercontent.com/khamer/base16-dunst/master/themes/base16-default-dark.dunstrc >> ~/.config/dunst/dunstrc
+curl https://raw.githubusercontent.com/tinted-theming/base16-dunst/master/themes/base16-default-dark.dunstrc >> ~/.config/dunst/dunstrc
 ```
 
 We used `msg_urgency` configuration instead of `urgency_low`, `urgency_normal`,


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.

(Github branch based on top of https://github.com/tinted-theming/base16-dunst/pull/7)