### PR TITLE
Quote msg_urgency to produce valid toml

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -3,16 +3,16 @@ frame_color = "#{{base05-hex}}"
 separator_color = "#{{base05-hex}}"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#{{base01-hex}}"
     foreground = "#{{base03-hex}}"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#{{base02-hex}}"
     foreground = "#{{base05-hex}}"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#{{base08-hex}}"
     foreground = "#{{base06-hex}}"

--- a/templates/inverted-backgrounds.mustache
+++ b/templates/inverted-backgrounds.mustache
@@ -3,16 +3,16 @@ frame_color = "#{{base05-hex}}"
 separator_color = "#{{base05-hex}}"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#{{base02-hex}}"
     foreground = "#{{base06-hex}}"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#{{base01-hex}}"
     foreground = "#{{base05-hex}}"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#{{base08-hex}}"
     foreground = "#{{base06-hex}}"

--- a/themes/base16-3024.dunstrc
+++ b/themes/base16-3024.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a5a2a2"
 separator_color = "#a5a2a2"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#3a3432"
     foreground = "#5c5855"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#4a4543"
     foreground = "#a5a2a2"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#db2d20"
     foreground = "#d6d5d4"

--- a/themes/base16-apathy.dunstrc
+++ b/themes/base16-apathy.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#81b5ac"
 separator_color = "#81b5ac"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#0b342d"
     foreground = "#2b685e"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#184e45"
     foreground = "#81b5ac"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#3e9688"
     foreground = "#a7cec8"

--- a/themes/base16-apprentice.dunstrc
+++ b/themes/base16-apprentice.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#5f5f87"
 separator_color = "#5f5f87"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#af5f5f"
     foreground = "#87875f"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5f875f"
     foreground = "#5f5f87"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#444444"
     foreground = "#5f8787"

--- a/themes/base16-ashes.dunstrc
+++ b/themes/base16-ashes.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c7ccd1"
 separator_color = "#c7ccd1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#393f45"
     foreground = "#747c84"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#565e65"
     foreground = "#c7ccd1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c7ae95"
     foreground = "#dfe2e5"

--- a/themes/base16-atelier-cave-light.dunstrc
+++ b/themes/base16-atelier-cave-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#585260"
 separator_color = "#585260"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e2dfe7"
     foreground = "#7e7887"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#8b8792"
     foreground = "#585260"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#be4678"
     foreground = "#26232a"

--- a/themes/base16-atelier-cave.dunstrc
+++ b/themes/base16-atelier-cave.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#8b8792"
 separator_color = "#8b8792"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#26232a"
     foreground = "#655f6d"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#585260"
     foreground = "#8b8792"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#be4678"
     foreground = "#e2dfe7"

--- a/themes/base16-atelier-dune-light.dunstrc
+++ b/themes/base16-atelier-dune-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#6e6b5e"
 separator_color = "#6e6b5e"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e8e4cf"
     foreground = "#999580"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#a6a28c"
     foreground = "#6e6b5e"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d73737"
     foreground = "#292824"

--- a/themes/base16-atelier-dune.dunstrc
+++ b/themes/base16-atelier-dune.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a6a28c"
 separator_color = "#a6a28c"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#292824"
     foreground = "#7d7a68"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#6e6b5e"
     foreground = "#a6a28c"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d73737"
     foreground = "#e8e4cf"

--- a/themes/base16-atelier-estuary-light.dunstrc
+++ b/themes/base16-atelier-estuary-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#5f5e4e"
 separator_color = "#5f5e4e"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e7e6df"
     foreground = "#878573"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#929181"
     foreground = "#5f5e4e"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ba6236"
     foreground = "#302f27"

--- a/themes/base16-atelier-estuary.dunstrc
+++ b/themes/base16-atelier-estuary.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#929181"
 separator_color = "#929181"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#302f27"
     foreground = "#6c6b5a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5f5e4e"
     foreground = "#929181"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ba6236"
     foreground = "#e7e6df"

--- a/themes/base16-atelier-forest-light.dunstrc
+++ b/themes/base16-atelier-forest-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#68615e"
 separator_color = "#68615e"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e6e2e0"
     foreground = "#9c9491"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#a8a19f"
     foreground = "#68615e"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f22c40"
     foreground = "#2c2421"

--- a/themes/base16-atelier-forest.dunstrc
+++ b/themes/base16-atelier-forest.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a8a19f"
 separator_color = "#a8a19f"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2c2421"
     foreground = "#766e6b"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#68615e"
     foreground = "#a8a19f"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f22c40"
     foreground = "#e6e2e0"

--- a/themes/base16-atelier-heath-light.dunstrc
+++ b/themes/base16-atelier-heath-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#695d69"
 separator_color = "#695d69"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#d8cad8"
     foreground = "#9e8f9e"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#ab9bab"
     foreground = "#695d69"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ca402b"
     foreground = "#292329"

--- a/themes/base16-atelier-heath.dunstrc
+++ b/themes/base16-atelier-heath.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#ab9bab"
 separator_color = "#ab9bab"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#292329"
     foreground = "#776977"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#695d69"
     foreground = "#ab9bab"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ca402b"
     foreground = "#d8cad8"

--- a/themes/base16-atelier-lakeside-light.dunstrc
+++ b/themes/base16-atelier-lakeside-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#516d7b"
 separator_color = "#516d7b"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#c1e4f6"
     foreground = "#7195a8"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#7ea2b4"
     foreground = "#516d7b"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d22d72"
     foreground = "#1f292e"

--- a/themes/base16-atelier-lakeside.dunstrc
+++ b/themes/base16-atelier-lakeside.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#7ea2b4"
 separator_color = "#7ea2b4"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1f292e"
     foreground = "#5a7b8c"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#516d7b"
     foreground = "#7ea2b4"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d22d72"
     foreground = "#c1e4f6"

--- a/themes/base16-atelier-plateau-light.dunstrc
+++ b/themes/base16-atelier-plateau-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#585050"
 separator_color = "#585050"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e7dfdf"
     foreground = "#7e7777"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#8a8585"
     foreground = "#585050"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ca4949"
     foreground = "#292424"

--- a/themes/base16-atelier-plateau.dunstrc
+++ b/themes/base16-atelier-plateau.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#8a8585"
 separator_color = "#8a8585"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#292424"
     foreground = "#655d5d"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#585050"
     foreground = "#8a8585"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ca4949"
     foreground = "#e7dfdf"

--- a/themes/base16-atelier-savanna-light.dunstrc
+++ b/themes/base16-atelier-savanna-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#526057"
 separator_color = "#526057"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#dfe7e2"
     foreground = "#78877d"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#87928a"
     foreground = "#526057"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#b16139"
     foreground = "#232a25"

--- a/themes/base16-atelier-savanna.dunstrc
+++ b/themes/base16-atelier-savanna.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#87928a"
 separator_color = "#87928a"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#232a25"
     foreground = "#5f6d64"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#526057"
     foreground = "#87928a"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#b16139"
     foreground = "#dfe7e2"

--- a/themes/base16-atelier-seaside-light.dunstrc
+++ b/themes/base16-atelier-seaside-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#5e6e5e"
 separator_color = "#5e6e5e"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#cfe8cf"
     foreground = "#809980"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#8ca68c"
     foreground = "#5e6e5e"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e6193c"
     foreground = "#242924"

--- a/themes/base16-atelier-seaside.dunstrc
+++ b/themes/base16-atelier-seaside.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#8ca68c"
 separator_color = "#8ca68c"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#242924"
     foreground = "#687d68"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5e6e5e"
     foreground = "#8ca68c"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e6193c"
     foreground = "#cfe8cf"

--- a/themes/base16-atelier-sulphurpool-light.dunstrc
+++ b/themes/base16-atelier-sulphurpool-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#5e6687"
 separator_color = "#5e6687"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#dfe2f1"
     foreground = "#898ea4"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#979db4"
     foreground = "#5e6687"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c94922"
     foreground = "#293256"

--- a/themes/base16-atelier-sulphurpool.dunstrc
+++ b/themes/base16-atelier-sulphurpool.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#979db4"
 separator_color = "#979db4"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#293256"
     foreground = "#6b7394"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5e6687"
     foreground = "#979db4"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c94922"
     foreground = "#dfe2f1"

--- a/themes/base16-atlas.dunstrc
+++ b/themes/base16-atlas.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a1a19a"
 separator_color = "#a1a19a"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#00384d"
     foreground = "#6c8b91"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#517f8d"
     foreground = "#a1a19a"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff5a67"
     foreground = "#e6e6dc"

--- a/themes/base16-ayu-dark.dunstrc
+++ b/themes/base16-ayu-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#e6e1cf"
 separator_color = "#e6e1cf"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#131721"
     foreground = "#3e4b59"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#272d38"
     foreground = "#e6e1cf"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f07178"
     foreground = "#e6e1cf"

--- a/themes/base16-ayu-light.dunstrc
+++ b/themes/base16-ayu-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#5c6773"
 separator_color = "#5c6773"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#f3f4f5"
     foreground = "#abb0b6"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#f8f9fa"
     foreground = "#5c6773"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f07178"
     foreground = "#242936"

--- a/themes/base16-ayu-mirage.dunstrc
+++ b/themes/base16-ayu-mirage.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cccac2"
 separator_color = "#cccac2"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1f2430"
     foreground = "#707a8c"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#242936"
     foreground = "#cccac2"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f28779"
     foreground = "#d9d7ce"

--- a/themes/base16-bespin.dunstrc
+++ b/themes/base16-bespin.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#8a8986"
 separator_color = "#8a8986"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#36312e"
     foreground = "#666666"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5e5d5c"
     foreground = "#8a8986"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#cf6a4c"
     foreground = "#9d9b97"

--- a/themes/base16-black-metal-bathory.dunstrc
+++ b/themes/base16-black-metal-bathory.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c1c1c1"
 separator_color = "#c1c1c1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#121212"
     foreground = "#333333"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#222222"
     foreground = "#c1c1c1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#5f8787"
     foreground = "#999999"

--- a/themes/base16-black-metal-burzum.dunstrc
+++ b/themes/base16-black-metal-burzum.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c1c1c1"
 separator_color = "#c1c1c1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#121212"
     foreground = "#333333"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#222222"
     foreground = "#c1c1c1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#5f8787"
     foreground = "#999999"

--- a/themes/base16-black-metal-dark-funeral.dunstrc
+++ b/themes/base16-black-metal-dark-funeral.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c1c1c1"
 separator_color = "#c1c1c1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#121212"
     foreground = "#333333"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#222222"
     foreground = "#c1c1c1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#5f8787"
     foreground = "#999999"

--- a/themes/base16-black-metal-gorgoroth.dunstrc
+++ b/themes/base16-black-metal-gorgoroth.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c1c1c1"
 separator_color = "#c1c1c1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#121212"
     foreground = "#333333"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#222222"
     foreground = "#c1c1c1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#5f8787"
     foreground = "#999999"

--- a/themes/base16-black-metal-immortal.dunstrc
+++ b/themes/base16-black-metal-immortal.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c1c1c1"
 separator_color = "#c1c1c1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#121212"
     foreground = "#333333"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#222222"
     foreground = "#c1c1c1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#5f8787"
     foreground = "#999999"

--- a/themes/base16-black-metal-khold.dunstrc
+++ b/themes/base16-black-metal-khold.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c1c1c1"
 separator_color = "#c1c1c1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#121212"
     foreground = "#333333"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#222222"
     foreground = "#c1c1c1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#5f8787"
     foreground = "#999999"

--- a/themes/base16-black-metal-marduk.dunstrc
+++ b/themes/base16-black-metal-marduk.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c1c1c1"
 separator_color = "#c1c1c1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#121212"
     foreground = "#333333"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#222222"
     foreground = "#c1c1c1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#5f8787"
     foreground = "#999999"

--- a/themes/base16-black-metal-mayhem.dunstrc
+++ b/themes/base16-black-metal-mayhem.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c1c1c1"
 separator_color = "#c1c1c1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#121212"
     foreground = "#333333"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#222222"
     foreground = "#c1c1c1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#5f8787"
     foreground = "#999999"

--- a/themes/base16-black-metal-nile.dunstrc
+++ b/themes/base16-black-metal-nile.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c1c1c1"
 separator_color = "#c1c1c1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#121212"
     foreground = "#333333"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#222222"
     foreground = "#c1c1c1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#5f8787"
     foreground = "#999999"

--- a/themes/base16-black-metal-venom.dunstrc
+++ b/themes/base16-black-metal-venom.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c1c1c1"
 separator_color = "#c1c1c1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#121212"
     foreground = "#333333"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#222222"
     foreground = "#c1c1c1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#5f8787"
     foreground = "#999999"

--- a/themes/base16-black-metal.dunstrc
+++ b/themes/base16-black-metal.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c1c1c1"
 separator_color = "#c1c1c1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#121212"
     foreground = "#333333"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#222222"
     foreground = "#c1c1c1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#5f8787"
     foreground = "#999999"

--- a/themes/base16-blueforest.dunstrc
+++ b/themes/base16-blueforest.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#ffcc33"
 separator_color = "#ffcc33"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1e5c1e"
     foreground = "#a0ffa0"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#273e5c"
     foreground = "#ffcc33"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fffab1"
     foreground = "#91ccff"

--- a/themes/base16-blueish.dunstrc
+++ b/themes/base16-blueish.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c8e1f8"
 separator_color = "#c8e1f8"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#243c54"
     foreground = "#616d78"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#46290a"
     foreground = "#c8e1f8"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#4ce587"
     foreground = "#ddeaf6"

--- a/themes/base16-brewer.dunstrc
+++ b/themes/base16-brewer.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#b7b8b9"
 separator_color = "#b7b8b9"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2e2f30"
     foreground = "#737475"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#515253"
     foreground = "#b7b8b9"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e31a1c"
     foreground = "#dadbdc"

--- a/themes/base16-bright.dunstrc
+++ b/themes/base16-bright.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#e0e0e0"
 separator_color = "#e0e0e0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#303030"
     foreground = "#b0b0b0"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#505050"
     foreground = "#e0e0e0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fb0120"
     foreground = "#f5f5f5"

--- a/themes/base16-brogrammer.dunstrc
+++ b/themes/base16-brogrammer.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#4e5ab7"
 separator_color = "#4e5ab7"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#f81118"
     foreground = "#ecba0f"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#2dc55e"
     foreground = "#4e5ab7"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d6dbe5"
     foreground = "#1081d6"

--- a/themes/base16-brushtrees-dark.dunstrc
+++ b/themes/base16-brushtrees-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#b0c5c8"
 separator_color = "#b0c5c8"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#5a6d7a"
     foreground = "#8299a1"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#6d828e"
     foreground = "#b0c5c8"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#b38686"
     foreground = "#c9dbdc"

--- a/themes/base16-brushtrees.dunstrc
+++ b/themes/base16-brushtrees.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#6d828e"
 separator_color = "#6d828e"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#c9dbdc"
     foreground = "#98afb5"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#b0c5c8"
     foreground = "#6d828e"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#b38686"
     foreground = "#5a6d7a"

--- a/themes/base16-catppuccin-frappe.dunstrc
+++ b/themes/base16-catppuccin-frappe.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c6d0f5"
 separator_color = "#c6d0f5"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#292c3c"
     foreground = "#51576d"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#414559"
     foreground = "#c6d0f5"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e78284"
     foreground = "#f2d5cf"

--- a/themes/base16-catppuccin-latte.dunstrc
+++ b/themes/base16-catppuccin-latte.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#4c4f69"
 separator_color = "#4c4f69"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e6e9ef"
     foreground = "#bcc0cc"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#ccd0da"
     foreground = "#4c4f69"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d20f39"
     foreground = "#dc8a78"

--- a/themes/base16-catppuccin-macchiato.dunstrc
+++ b/themes/base16-catppuccin-macchiato.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cad3f5"
 separator_color = "#cad3f5"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1e2030"
     foreground = "#494d64"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#363a4f"
     foreground = "#cad3f5"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ed8796"
     foreground = "#f4dbd6"

--- a/themes/base16-catppuccin-mocha.dunstrc
+++ b/themes/base16-catppuccin-mocha.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cdd6f4"
 separator_color = "#cdd6f4"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#181825"
     foreground = "#45475a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#313244"
     foreground = "#cdd6f4"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f38ba8"
     foreground = "#f5e0dc"

--- a/themes/base16-chalk.dunstrc
+++ b/themes/base16-chalk.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d0d0d0"
 separator_color = "#d0d0d0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#202020"
     foreground = "#505050"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#303030"
     foreground = "#d0d0d0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fb9fb1"
     foreground = "#e0e0e0"

--- a/themes/base16-circus.dunstrc
+++ b/themes/base16-circus.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a7a7a7"
 separator_color = "#a7a7a7"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#202020"
     foreground = "#5f5a60"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#303030"
     foreground = "#a7a7a7"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#dc657d"
     foreground = "#808080"

--- a/themes/base16-classic-dark.dunstrc
+++ b/themes/base16-classic-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d0d0d0"
 separator_color = "#d0d0d0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#202020"
     foreground = "#505050"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#303030"
     foreground = "#d0d0d0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ac4142"
     foreground = "#e0e0e0"

--- a/themes/base16-classic-light.dunstrc
+++ b/themes/base16-classic-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#303030"
 separator_color = "#303030"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e0e0e0"
     foreground = "#b0b0b0"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d0d0d0"
     foreground = "#303030"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ac4142"
     foreground = "#202020"

--- a/themes/base16-codeschool.dunstrc
+++ b/themes/base16-codeschool.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#9ea7a6"
 separator_color = "#9ea7a6"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1c3657"
     foreground = "#3f4944"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#2a343a"
     foreground = "#9ea7a6"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#2a5491"
     foreground = "#a7cfa3"

--- a/themes/base16-colors.dunstrc
+++ b/themes/base16-colors.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#bbbbbb"
 separator_color = "#bbbbbb"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#333333"
     foreground = "#777777"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#555555"
     foreground = "#bbbbbb"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff4136"
     foreground = "#dddddd"

--- a/themes/base16-cupcake.dunstrc
+++ b/themes/base16-cupcake.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#8b8198"
 separator_color = "#8b8198"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#f2f1f4"
     foreground = "#bfb9c6"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d8d5dd"
     foreground = "#8b8198"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d57e85"
     foreground = "#72677e"

--- a/themes/base16-cupertino.dunstrc
+++ b/themes/base16-cupertino.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#404040"
 separator_color = "#404040"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#c0c0c0"
     foreground = "#808080"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#c0c0c0"
     foreground = "#404040"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c41a15"
     foreground = "#404040"

--- a/themes/base16-da-one-black.dunstrc
+++ b/themes/base16-da-one-black.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#ffffff"
 separator_color = "#ffffff"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#282828"
     foreground = "#888888"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#585858"
     foreground = "#ffffff"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fa7883"
     foreground = "#ffffff"

--- a/themes/base16-da-one-gray.dunstrc
+++ b/themes/base16-da-one-gray.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#ffffff"
 separator_color = "#ffffff"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#282828"
     foreground = "#888888"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#585858"
     foreground = "#ffffff"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fa7883"
     foreground = "#ffffff"

--- a/themes/base16-da-one-ocean.dunstrc
+++ b/themes/base16-da-one-ocean.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#ffffff"
 separator_color = "#ffffff"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#22273d"
     foreground = "#878d96"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#525866"
     foreground = "#ffffff"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fa7883"
     foreground = "#ffffff"

--- a/themes/base16-da-one-paper.dunstrc
+++ b/themes/base16-da-one-paper.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#181818"
 separator_color = "#181818"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#c8c8c8"
     foreground = "#585858"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#888888"
     foreground = "#181818"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#de5d6e"
     foreground = "#000000"

--- a/themes/base16-da-one-sea.dunstrc
+++ b/themes/base16-da-one-sea.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#ffffff"
 separator_color = "#ffffff"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#374059"
     foreground = "#878d96"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#525866"
     foreground = "#ffffff"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fa7883"
     foreground = "#ffffff"

--- a/themes/base16-da-one-white.dunstrc
+++ b/themes/base16-da-one-white.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#181818"
 separator_color = "#181818"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#c8c8c8"
     foreground = "#585858"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#888888"
     foreground = "#181818"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#de5d6e"
     foreground = "#000000"

--- a/themes/base16-danqing-light.dunstrc
+++ b/themes/base16-danqing-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#5a605d"
 separator_color = "#5a605d"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#ecf6f2"
     foreground = "#cad8d2"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#e0f0ef"
     foreground = "#5a605d"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f9906f"
     foreground = "#434846"

--- a/themes/base16-danqing.dunstrc
+++ b/themes/base16-danqing.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#e0f0ef"
 separator_color = "#e0f0ef"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#434846"
     foreground = "#9da8a3"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5a605d"
     foreground = "#e0f0ef"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f9906f"
     foreground = "#ecf6f2"

--- a/themes/base16-darcula.dunstrc
+++ b/themes/base16-darcula.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a9b7c6"
 separator_color = "#a9b7c6"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#323232"
     foreground = "#606366"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#323232"
     foreground = "#a9b7c6"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#4eade5"
     foreground = "#ffc66d"

--- a/themes/base16-darkmoss.dunstrc
+++ b/themes/base16-darkmoss.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c7c7a5"
 separator_color = "#c7c7a5"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#252c2d"
     foreground = "#555e5f"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#373c3d"
     foreground = "#c7c7a5"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff4658"
     foreground = "#e3e3c8"

--- a/themes/base16-darktooth.dunstrc
+++ b/themes/base16-darktooth.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a89984"
 separator_color = "#a89984"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#32302f"
     foreground = "#665c54"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#504945"
     foreground = "#a89984"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fb543f"
     foreground = "#d5c4a1"

--- a/themes/base16-darkviolet.dunstrc
+++ b/themes/base16-darkviolet.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#b08ae6"
 separator_color = "#b08ae6"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#231a40"
     foreground = "#593380"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#432d59"
     foreground = "#b08ae6"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#a82ee6"
     foreground = "#9045e6"

--- a/themes/base16-decaf.dunstrc
+++ b/themes/base16-decaf.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cccccc"
 separator_color = "#cccccc"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#393939"
     foreground = "#777777"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#515151"
     foreground = "#cccccc"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff7f7b"
     foreground = "#e0e0e0"

--- a/themes/base16-default-dark.dunstrc
+++ b/themes/base16-default-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d8d8d8"
 separator_color = "#d8d8d8"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#282828"
     foreground = "#585858"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#383838"
     foreground = "#d8d8d8"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ab4642"
     foreground = "#e8e8e8"

--- a/themes/base16-default-light.dunstrc
+++ b/themes/base16-default-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#383838"
 separator_color = "#383838"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e8e8e8"
     foreground = "#b8b8b8"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d8d8d8"
     foreground = "#383838"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ab4642"
     foreground = "#282828"

--- a/themes/base16-dirtysea.dunstrc
+++ b/themes/base16-dirtysea.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#000000"
 separator_color = "#000000"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#d0dad0"
     foreground = "#707070"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d0d0d0"
     foreground = "#000000"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#840000"
     foreground = "#f8f8f8"

--- a/themes/base16-dracula.dunstrc
+++ b/themes/base16-dracula.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#e9e9f4"
 separator_color = "#e9e9f4"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#3a3c4e"
     foreground = "#626483"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#4d4f68"
     foreground = "#e9e9f4"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ea51b2"
     foreground = "#f1f2f8"

--- a/themes/base16-edge-dark.dunstrc
+++ b/themes/base16-edge-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#b7bec9"
 separator_color = "#b7bec9"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#88909f"
     foreground = "#3e4249"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#b7bec9"
     foreground = "#b7bec9"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e77171"
     foreground = "#d390e7"

--- a/themes/base16-edge-light.dunstrc
+++ b/themes/base16-edge-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#5e646f"
 separator_color = "#5e646f"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#7c9f4b"
     foreground = "#5e646f"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d69822"
     foreground = "#5e646f"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#db7070"
     foreground = "#b870ce"

--- a/themes/base16-eighties.dunstrc
+++ b/themes/base16-eighties.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d3d0c8"
 separator_color = "#d3d0c8"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#393939"
     foreground = "#747369"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#515151"
     foreground = "#d3d0c8"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f2777a"
     foreground = "#e8e6df"

--- a/themes/base16-embers.dunstrc
+++ b/themes/base16-embers.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a39a90"
 separator_color = "#a39a90"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2c2620"
     foreground = "#5a5047"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#433b32"
     foreground = "#a39a90"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#826d57"
     foreground = "#beb6ae"

--- a/themes/base16-emil.dunstrc
+++ b/themes/base16-emil.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#313145"
 separator_color = "#313145"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#bebed2"
     foreground = "#7c7c98"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#9e9eaf"
     foreground = "#313145"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f43979"
     foreground = "#22223a"

--- a/themes/base16-equilibrium-dark.dunstrc
+++ b/themes/base16-equilibrium-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#afaba2"
 separator_color = "#afaba2"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#181c22"
     foreground = "#7b776e"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#22262d"
     foreground = "#afaba2"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f04339"
     foreground = "#cac6bd"

--- a/themes/base16-equilibrium-gray-dark.dunstrc
+++ b/themes/base16-equilibrium-gray-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#ababab"
 separator_color = "#ababab"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1b1b1b"
     foreground = "#777777"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#262626"
     foreground = "#ababab"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f04339"
     foreground = "#c6c6c6"

--- a/themes/base16-equilibrium-gray-light.dunstrc
+++ b/themes/base16-equilibrium-gray-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#474747"
 separator_color = "#474747"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e2e2e2"
     foreground = "#777777"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d4d4d4"
     foreground = "#474747"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d02023"
     foreground = "#303030"

--- a/themes/base16-equilibrium-light.dunstrc
+++ b/themes/base16-equilibrium-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#43474e"
 separator_color = "#43474e"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e7e2d9"
     foreground = "#73777f"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d8d4cb"
     foreground = "#43474e"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d02023"
     foreground = "#2c3138"

--- a/themes/base16-espresso.dunstrc
+++ b/themes/base16-espresso.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cccccc"
 separator_color = "#cccccc"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#393939"
     foreground = "#777777"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#515151"
     foreground = "#cccccc"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d25252"
     foreground = "#e0e0e0"

--- a/themes/base16-eva-dim.dunstrc
+++ b/themes/base16-eva-dim.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#9fa2a6"
 separator_color = "#9fa2a6"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#3d566f"
     foreground = "#55799c"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#4b6988"
     foreground = "#9fa2a6"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c4676c"
     foreground = "#d6d7d9"

--- a/themes/base16-eva.dunstrc
+++ b/themes/base16-eva.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#9fa2a6"
 separator_color = "#9fa2a6"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#3d566f"
     foreground = "#55799c"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#4b6988"
     foreground = "#9fa2a6"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c4676c"
     foreground = "#d6d7d9"

--- a/themes/base16-evenok-dark.dunstrc
+++ b/themes/base16-evenok-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d0d0d0"
 separator_color = "#d0d0d0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#202020"
     foreground = "#505050"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#303030"
     foreground = "#d0d0d0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f5708a"
     foreground = "#e0e0e0"

--- a/themes/base16-everforest.dunstrc
+++ b/themes/base16-everforest.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d3c6aa"
 separator_color = "#d3c6aa"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#374247"
     foreground = "#859289"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#4a555b"
     foreground = "#d3c6aa"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#7fbbb3"
     foreground = "#e4e1cd"

--- a/themes/base16-flat.dunstrc
+++ b/themes/base16-flat.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#e0e0e0"
 separator_color = "#e0e0e0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#34495e"
     foreground = "#95a5a6"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#7f8c8d"
     foreground = "#e0e0e0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e74c3c"
     foreground = "#f5f5f5"

--- a/themes/base16-framer.dunstrc
+++ b/themes/base16-framer.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d0d0d0"
 separator_color = "#d0d0d0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#151515"
     foreground = "#747474"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#464646"
     foreground = "#d0d0d0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fd886b"
     foreground = "#e8e8e8"

--- a/themes/base16-fruit-soda.dunstrc
+++ b/themes/base16-fruit-soda.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#515151"
 separator_color = "#515151"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e0dee0"
     foreground = "#b5b4b6"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d8d5d5"
     foreground = "#515151"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fe3e31"
     foreground = "#474545"

--- a/themes/base16-gigavolt.dunstrc
+++ b/themes/base16-gigavolt.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#e9e7e1"
 separator_color = "#e9e7e1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2d303d"
     foreground = "#a1d2e6"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5a576e"
     foreground = "#e9e7e1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff661a"
     foreground = "#eff0f9"

--- a/themes/base16-github.dunstrc
+++ b/themes/base16-github.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#333333"
 separator_color = "#333333"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#f5f5f5"
     foreground = "#969896"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#c8c8fa"
     foreground = "#333333"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ed6a43"
     foreground = "#ffffff"

--- a/themes/base16-google-dark.dunstrc
+++ b/themes/base16-google-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c5c8c6"
 separator_color = "#c5c8c6"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#282a2e"
     foreground = "#969896"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#373b41"
     foreground = "#c5c8c6"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#cc342b"
     foreground = "#e0e0e0"

--- a/themes/base16-google-light.dunstrc
+++ b/themes/base16-google-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#373b41"
 separator_color = "#373b41"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e0e0e0"
     foreground = "#b4b7b4"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#c5c8c6"
     foreground = "#373b41"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#cc342b"
     foreground = "#282a2e"

--- a/themes/base16-gotham.dunstrc
+++ b/themes/base16-gotham.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#599cab"
 separator_color = "#599cab"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#11151c"
     foreground = "#0a3749"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#091f2e"
     foreground = "#599cab"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c23127"
     foreground = "#99d1ce"

--- a/themes/base16-grayscale-dark.dunstrc
+++ b/themes/base16-grayscale-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#b9b9b9"
 separator_color = "#b9b9b9"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#252525"
     foreground = "#525252"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#464646"
     foreground = "#b9b9b9"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#7c7c7c"
     foreground = "#e3e3e3"

--- a/themes/base16-grayscale-light.dunstrc
+++ b/themes/base16-grayscale-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#464646"
 separator_color = "#464646"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e3e3e3"
     foreground = "#ababab"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#b9b9b9"
     foreground = "#464646"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#7c7c7c"
     foreground = "#252525"

--- a/themes/base16-greenscreen.dunstrc
+++ b/themes/base16-greenscreen.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#00bb00"
 separator_color = "#00bb00"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#003300"
     foreground = "#007700"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#005500"
     foreground = "#00bb00"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#007700"
     foreground = "#00dd00"

--- a/themes/base16-gruber.dunstrc
+++ b/themes/base16-gruber.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#f4f4ff"
 separator_color = "#f4f4ff"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#453d41"
     foreground = "#52494e"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#484848"
     foreground = "#f4f4ff"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f43841"
     foreground = "#f5f5f5"

--- a/themes/base16-gruvbox-dark-hard.dunstrc
+++ b/themes/base16-gruvbox-dark-hard.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d5c4a1"
 separator_color = "#d5c4a1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#3c3836"
     foreground = "#665c54"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#504945"
     foreground = "#d5c4a1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fb4934"
     foreground = "#ebdbb2"

--- a/themes/base16-gruvbox-dark-medium.dunstrc
+++ b/themes/base16-gruvbox-dark-medium.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d5c4a1"
 separator_color = "#d5c4a1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#3c3836"
     foreground = "#665c54"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#504945"
     foreground = "#d5c4a1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fb4934"
     foreground = "#ebdbb2"

--- a/themes/base16-gruvbox-dark-pale.dunstrc
+++ b/themes/base16-gruvbox-dark-pale.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#dab997"
 separator_color = "#dab997"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#3a3a3a"
     foreground = "#8a8a8a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#4e4e4e"
     foreground = "#dab997"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d75f5f"
     foreground = "#d5c4a1"

--- a/themes/base16-gruvbox-dark-soft.dunstrc
+++ b/themes/base16-gruvbox-dark-soft.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d5c4a1"
 separator_color = "#d5c4a1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#3c3836"
     foreground = "#665c54"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#504945"
     foreground = "#d5c4a1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fb4934"
     foreground = "#ebdbb2"

--- a/themes/base16-gruvbox-light-hard.dunstrc
+++ b/themes/base16-gruvbox-light-hard.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#504945"
 separator_color = "#504945"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#ebdbb2"
     foreground = "#bdae93"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d5c4a1"
     foreground = "#504945"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#9d0006"
     foreground = "#3c3836"

--- a/themes/base16-gruvbox-light-medium.dunstrc
+++ b/themes/base16-gruvbox-light-medium.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#504945"
 separator_color = "#504945"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#ebdbb2"
     foreground = "#bdae93"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d5c4a1"
     foreground = "#504945"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#9d0006"
     foreground = "#3c3836"

--- a/themes/base16-gruvbox-light-soft.dunstrc
+++ b/themes/base16-gruvbox-light-soft.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#504945"
 separator_color = "#504945"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#ebdbb2"
     foreground = "#bdae93"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d5c4a1"
     foreground = "#504945"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#9d0006"
     foreground = "#3c3836"

--- a/themes/base16-gruvbox-material-dark-hard.dunstrc
+++ b/themes/base16-gruvbox-material-dark-hard.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#ddc7a1"
 separator_color = "#ddc7a1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2a2827"
     foreground = "#5a524c"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#504945"
     foreground = "#ddc7a1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ea6962"
     foreground = "#ebdbb2"

--- a/themes/base16-gruvbox-material-dark-medium.dunstrc
+++ b/themes/base16-gruvbox-material-dark-medium.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#ddc7a1"
 separator_color = "#ddc7a1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#32302f"
     foreground = "#665c54"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#504945"
     foreground = "#ddc7a1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ea6962"
     foreground = "#ebdbb2"

--- a/themes/base16-gruvbox-material-dark-soft.dunstrc
+++ b/themes/base16-gruvbox-material-dark-soft.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#ddc7a1"
 separator_color = "#ddc7a1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#3c3836"
     foreground = "#7c6f64"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5a524c"
     foreground = "#ddc7a1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ea6962"
     foreground = "#ebdbb2"

--- a/themes/base16-gruvbox-material-light-hard.dunstrc
+++ b/themes/base16-gruvbox-material-light-hard.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#654735"
 separator_color = "#654735"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#fbf1c7"
     foreground = "#a89984"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#e0cfa9"
     foreground = "#654735"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c14a4a"
     foreground = "#3c3836"

--- a/themes/base16-gruvbox-material-light-medium.dunstrc
+++ b/themes/base16-gruvbox-material-light-medium.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#654735"
 separator_color = "#654735"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#f2e5bc"
     foreground = "#bdae93"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d5c4a1"
     foreground = "#654735"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c14a4a"
     foreground = "#3c3836"

--- a/themes/base16-gruvbox-material-light-soft.dunstrc
+++ b/themes/base16-gruvbox-material-light-soft.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#654735"
 separator_color = "#654735"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#ebdbb2"
     foreground = "#a89984"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#c9b99a"
     foreground = "#654735"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c14a4a"
     foreground = "#3c3836"

--- a/themes/base16-hardcore.dunstrc
+++ b/themes/base16-hardcore.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cdcdcd"
 separator_color = "#cdcdcd"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#303030"
     foreground = "#4a4a4a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#353535"
     foreground = "#cdcdcd"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f92672"
     foreground = "#e5e5e5"

--- a/themes/base16-harmonic-dark.dunstrc
+++ b/themes/base16-harmonic-dark.dunstrc
@@ -2,16 +2,16 @@ frame_color = "#cbd6e2"
 separator_color = "#cbd6e2"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#223b54"
     foreground = "#627e99"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#405c79"
     foreground = "#cbd6e2"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#bf8b56"
     foreground = "#e5ebf1"

--- a/themes/base16-harmonic-light.dunstrc
+++ b/themes/base16-harmonic-light.dunstrc
@@ -2,16 +2,16 @@ frame_color = "#405c79"
 separator_color = "#405c79"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e5ebf1"
     foreground = "#aabcce"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#cbd6e2"
     foreground = "#405c79"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#bf8b56"
     foreground = "#223b54"

--- a/themes/base16-harmonic16-dark.dunstrc
+++ b/themes/base16-harmonic16-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cbd6e2"
 separator_color = "#cbd6e2"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#223b54"
     foreground = "#627e99"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#405c79"
     foreground = "#cbd6e2"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#bf8b56"
     foreground = "#e5ebf1"

--- a/themes/base16-harmonic16-light.dunstrc
+++ b/themes/base16-harmonic16-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#405c79"
 separator_color = "#405c79"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e5ebf1"
     foreground = "#aabcce"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#cbd6e2"
     foreground = "#405c79"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#bf8b56"
     foreground = "#223b54"

--- a/themes/base16-heetch-light.dunstrc
+++ b/themes/base16-heetch-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#5a496e"
 separator_color = "#5a496e"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#392551"
     foreground = "#9c92a8"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#7b6d8b"
     foreground = "#5a496e"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#27d9d5"
     foreground = "#470546"

--- a/themes/base16-heetch.dunstrc
+++ b/themes/base16-heetch.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#bdb6c5"
 separator_color = "#bdb6c5"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#392551"
     foreground = "#7b6d8b"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5a496e"
     foreground = "#bdb6c5"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#27d9d5"
     foreground = "#dedae2"

--- a/themes/base16-helios.dunstrc
+++ b/themes/base16-helios.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d5d5d5"
 separator_color = "#d5d5d5"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#383c3e"
     foreground = "#6f7579"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#53585b"
     foreground = "#d5d5d5"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d72638"
     foreground = "#dddddd"

--- a/themes/base16-hopscotch.dunstrc
+++ b/themes/base16-hopscotch.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#b9b5b8"
 separator_color = "#b9b5b8"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#433b42"
     foreground = "#797379"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5c545b"
     foreground = "#b9b5b8"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#dd464c"
     foreground = "#d5d3d5"

--- a/themes/base16-horizon-dark.dunstrc
+++ b/themes/base16-horizon-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cbced0"
 separator_color = "#cbced0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#232530"
     foreground = "#6f6f70"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#2e303e"
     foreground = "#cbced0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e93c58"
     foreground = "#dcdfe4"

--- a/themes/base16-horizon-light.dunstrc
+++ b/themes/base16-horizon-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#403c3d"
 separator_color = "#403c3d"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#fadad1"
     foreground = "#bdb3b1"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#f9cbbe"
     foreground = "#403c3d"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f7939b"
     foreground = "#302c2d"

--- a/themes/base16-horizon-terminal-dark.dunstrc
+++ b/themes/base16-horizon-terminal-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cbced0"
 separator_color = "#cbced0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#232530"
     foreground = "#6f6f70"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#2e303e"
     foreground = "#cbced0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e95678"
     foreground = "#dcdfe4"

--- a/themes/base16-horizon-terminal-light.dunstrc
+++ b/themes/base16-horizon-terminal-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#403c3d"
 separator_color = "#403c3d"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#fadad1"
     foreground = "#bdb3b1"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#f9cbbe"
     foreground = "#403c3d"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e95678"
     foreground = "#302c2d"

--- a/themes/base16-humanoid-dark.dunstrc
+++ b/themes/base16-humanoid-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#f8f8f2"
 separator_color = "#f8f8f2"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#333b3d"
     foreground = "#60615d"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#484e54"
     foreground = "#f8f8f2"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f11235"
     foreground = "#fcfcf6"

--- a/themes/base16-humanoid-light.dunstrc
+++ b/themes/base16-humanoid-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#232629"
 separator_color = "#232629"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#efefe9"
     foreground = "#c0c0bd"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#deded8"
     foreground = "#232629"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#b0151a"
     foreground = "#2f3337"

--- a/themes/base16-ia-dark.dunstrc
+++ b/themes/base16-ia-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cccccc"
 separator_color = "#cccccc"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#222222"
     foreground = "#767676"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#1d414d"
     foreground = "#cccccc"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d88568"
     foreground = "#e8e8e8"

--- a/themes/base16-ia-light.dunstrc
+++ b/themes/base16-ia-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#181818"
 separator_color = "#181818"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#dedede"
     foreground = "#898989"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#bde5f2"
     foreground = "#181818"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#9c5a02"
     foreground = "#e8e8e8"

--- a/themes/base16-icy.dunstrc
+++ b/themes/base16-icy.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#095b67"
 separator_color = "#095b67"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#031619"
     foreground = "#052e34"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#041f23"
     foreground = "#095b67"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#16c1d9"
     foreground = "#0c7c8c"

--- a/themes/base16-irblack.dunstrc
+++ b/themes/base16-irblack.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#b5b3aa"
 separator_color = "#b5b3aa"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#242422"
     foreground = "#6c6c66"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#484844"
     foreground = "#b5b3aa"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff6c60"
     foreground = "#d9d7cc"

--- a/themes/base16-isotope.dunstrc
+++ b/themes/base16-isotope.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d0d0d0"
 separator_color = "#d0d0d0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#404040"
     foreground = "#808080"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#606060"
     foreground = "#d0d0d0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff0000"
     foreground = "#e0e0e0"

--- a/themes/base16-kanagawa.dunstrc
+++ b/themes/base16-kanagawa.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#dcd7ba"
 separator_color = "#dcd7ba"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#16161d"
     foreground = "#54546d"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#223249"
     foreground = "#dcd7ba"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c34043"
     foreground = "#c8c093"

--- a/themes/base16-katy.dunstrc
+++ b/themes/base16-katy.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#959dcb"
 separator_color = "#959dcb"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#444267"
     foreground = "#676e95"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5c598b"
     foreground = "#959dcb"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#6e98e1"
     foreground = "#959dcb"

--- a/themes/base16-kimber.dunstrc
+++ b/themes/base16-kimber.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#dedee7"
 separator_color = "#dedee7"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#313131"
     foreground = "#644646"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#555d55"
     foreground = "#dedee7"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c88c8c"
     foreground = "#c3c3b4"

--- a/themes/base16-lime.dunstrc
+++ b/themes/base16-lime.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#818175"
 separator_color = "#818175"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#202030"
     foreground = "#313140"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#2a2a3f"
     foreground = "#818175"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff662a"
     foreground = "#fff2d1"

--- a/themes/base16-macintosh.dunstrc
+++ b/themes/base16-macintosh.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c0c0c0"
 separator_color = "#c0c0c0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#404040"
     foreground = "#808080"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#404040"
     foreground = "#c0c0c0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#dd0907"
     foreground = "#c0c0c0"

--- a/themes/base16-marrakesh.dunstrc
+++ b/themes/base16-marrakesh.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#948e48"
 separator_color = "#948e48"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#302e00"
     foreground = "#6c6823"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5f5b17"
     foreground = "#948e48"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c35359"
     foreground = "#ccc37a"

--- a/themes/base16-materia.dunstrc
+++ b/themes/base16-materia.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cdd3de"
 separator_color = "#cdd3de"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2c393f"
     foreground = "#707880"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#37474f"
     foreground = "#cdd3de"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ec5f67"
     foreground = "#d5dbe5"

--- a/themes/base16-material-darker.dunstrc
+++ b/themes/base16-material-darker.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#eeffff"
 separator_color = "#eeffff"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#303030"
     foreground = "#4a4a4a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#353535"
     foreground = "#eeffff"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f07178"
     foreground = "#eeffff"

--- a/themes/base16-material-lighter.dunstrc
+++ b/themes/base16-material-lighter.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#80cbc4"
 separator_color = "#80cbc4"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e7eaec"
     foreground = "#ccd7da"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#cceae7"
     foreground = "#80cbc4"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff5370"
     foreground = "#80cbc4"

--- a/themes/base16-material-palenight.dunstrc
+++ b/themes/base16-material-palenight.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#959dcb"
 separator_color = "#959dcb"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#444267"
     foreground = "#676e95"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#32374d"
     foreground = "#959dcb"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f07178"
     foreground = "#959dcb"

--- a/themes/base16-material-vivid.dunstrc
+++ b/themes/base16-material-vivid.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#80868b"
 separator_color = "#80868b"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#27292c"
     foreground = "#44464d"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#323639"
     foreground = "#80868b"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f44336"
     foreground = "#9e9e9e"

--- a/themes/base16-material.dunstrc
+++ b/themes/base16-material.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#eeffff"
 separator_color = "#eeffff"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2e3c43"
     foreground = "#546e7a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#314549"
     foreground = "#eeffff"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f07178"
     foreground = "#eeffff"

--- a/themes/base16-mellow-purple.dunstrc
+++ b/themes/base16-mellow-purple.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#ffeeff"
 separator_color = "#ffeeff"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1a092d"
     foreground = "#320f55"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#331354"
     foreground = "#ffeeff"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#00d9e9"
     foreground = "#ffeeff"

--- a/themes/base16-mexico-light.dunstrc
+++ b/themes/base16-mexico-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#383838"
 separator_color = "#383838"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e8e8e8"
     foreground = "#b8b8b8"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d8d8d8"
     foreground = "#383838"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ab4642"
     foreground = "#282828"

--- a/themes/base16-mocha.dunstrc
+++ b/themes/base16-mocha.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d0c8c6"
 separator_color = "#d0c8c6"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#534636"
     foreground = "#7e705a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#645240"
     foreground = "#d0c8c6"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#cb6077"
     foreground = "#e9e1dd"

--- a/themes/base16-monokai.dunstrc
+++ b/themes/base16-monokai.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#f8f8f2"
 separator_color = "#f8f8f2"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#383830"
     foreground = "#75715e"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#49483e"
     foreground = "#f8f8f2"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f92672"
     foreground = "#f5f4f1"

--- a/themes/base16-mountain.dunstrc
+++ b/themes/base16-mountain.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cacaca"
 separator_color = "#cacaca"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#191919"
     foreground = "#4c4c4c"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#262626"
     foreground = "#cacaca"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ac8a8c"
     foreground = "#e7e7e7"

--- a/themes/base16-nebula.dunstrc
+++ b/themes/base16-nebula.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a4a6a9"
 separator_color = "#a4a6a9"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#414f60"
     foreground = "#6e6f72"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5a8380"
     foreground = "#a4a6a9"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#777abc"
     foreground = "#c7c9cd"

--- a/themes/base16-nord.dunstrc
+++ b/themes/base16-nord.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#e5e9f0"
 separator_color = "#e5e9f0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#3b4252"
     foreground = "#4c566a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#434c5e"
     foreground = "#e5e9f0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#bf616a"
     foreground = "#eceff4"

--- a/themes/base16-nova.dunstrc
+++ b/themes/base16-nova.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c5d4dd"
 separator_color = "#c5d4dd"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#556873"
     foreground = "#899ba6"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#6a7d89"
     foreground = "#c5d4dd"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#83afe5"
     foreground = "#899ba6"

--- a/themes/base16-ocean.dunstrc
+++ b/themes/base16-ocean.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c0c5ce"
 separator_color = "#c0c5ce"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#343d46"
     foreground = "#65737e"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#4f5b66"
     foreground = "#c0c5ce"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#bf616a"
     foreground = "#dfe1e8"

--- a/themes/base16-oceanicnext.dunstrc
+++ b/themes/base16-oceanicnext.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c0c5ce"
 separator_color = "#c0c5ce"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#343d46"
     foreground = "#65737e"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#4f5b66"
     foreground = "#c0c5ce"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ec5f67"
     foreground = "#cdd3de"

--- a/themes/base16-one-light.dunstrc
+++ b/themes/base16-one-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#383a42"
 separator_color = "#383a42"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#f0f0f1"
     foreground = "#a0a1a7"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#e5e5e6"
     foreground = "#383a42"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ca1243"
     foreground = "#202227"

--- a/themes/base16-onedark.dunstrc
+++ b/themes/base16-onedark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#abb2bf"
 separator_color = "#abb2bf"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#353b45"
     foreground = "#545862"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#3e4451"
     foreground = "#abb2bf"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e06c75"
     foreground = "#b6bdca"

--- a/themes/base16-outrun-dark.dunstrc
+++ b/themes/base16-outrun-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d0d0fa"
 separator_color = "#d0d0fa"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#20204a"
     foreground = "#50507a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#30305a"
     foreground = "#d0d0fa"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff4242"
     foreground = "#e0e0ff"

--- a/themes/base16-pandora.dunstrc
+++ b/themes/base16-pandora.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#f15c99"
 separator_color = "#f15c99"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2f1823"
     foreground = "#ffbee3"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#472234"
     foreground = "#f15c99"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#b00b69"
     foreground = "#81506a"

--- a/themes/base16-papercolor-dark.dunstrc
+++ b/themes/base16-papercolor-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#808080"
 separator_color = "#808080"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#af005f"
     foreground = "#d7af5f"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5faf00"
     foreground = "#808080"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#585858"
     foreground = "#d7875f"

--- a/themes/base16-papercolor-light.dunstrc
+++ b/themes/base16-papercolor-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#444444"
 separator_color = "#444444"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#af0000"
     foreground = "#5f8700"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#008700"
     foreground = "#444444"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#bcbcbc"
     foreground = "#005f87"

--- a/themes/base16-paraiso.dunstrc
+++ b/themes/base16-paraiso.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a39e9b"
 separator_color = "#a39e9b"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#41323f"
     foreground = "#776e71"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#4f424c"
     foreground = "#a39e9b"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ef6155"
     foreground = "#b9b6b0"

--- a/themes/base16-pasque.dunstrc
+++ b/themes/base16-pasque.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#dedcdf"
 separator_color = "#dedcdf"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#100323"
     foreground = "#5d5766"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#3e2d5c"
     foreground = "#dedcdf"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#a92258"
     foreground = "#edeaef"

--- a/themes/base16-phd.dunstrc
+++ b/themes/base16-phd.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#b8bbc2"
 separator_color = "#b8bbc2"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2a3448"
     foreground = "#717885"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#4d5666"
     foreground = "#b8bbc2"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d07346"
     foreground = "#dbdde0"

--- a/themes/base16-pico.dunstrc
+++ b/themes/base16-pico.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#5f574f"
 separator_color = "#5f574f"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1d2b53"
     foreground = "#008751"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#7e2553"
     foreground = "#5f574f"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff004d"
     foreground = "#c2c3c7"

--- a/themes/base16-pinky.dunstrc
+++ b/themes/base16-pinky.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#f5f5f5"
 separator_color = "#f5f5f5"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1b181b"
     foreground = "#383338"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#1d1b1d"
     foreground = "#f5f5f5"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ffa600"
     foreground = "#ffffff"

--- a/themes/base16-pop.dunstrc
+++ b/themes/base16-pop.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d0d0d0"
 separator_color = "#d0d0d0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#202020"
     foreground = "#505050"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#303030"
     foreground = "#d0d0d0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#eb008a"
     foreground = "#e0e0e0"

--- a/themes/base16-porple.dunstrc
+++ b/themes/base16-porple.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d8d8d8"
 separator_color = "#d8d8d8"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#333344"
     foreground = "#65568a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#474160"
     foreground = "#d8d8d8"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f84547"
     foreground = "#e8e8e8"

--- a/themes/base16-primer-dark-dimmed.dunstrc
+++ b/themes/base16-primer-dark-dimmed.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#909dab"
 separator_color = "#909dab"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#373e47"
     foreground = "#545d68"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#444c56"
     foreground = "#909dab"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f47067"
     foreground = "#adbac7"

--- a/themes/base16-primer-dark.dunstrc
+++ b/themes/base16-primer-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#b1bac4"
 separator_color = "#b1bac4"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#21262d"
     foreground = "#484f58"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#30363d"
     foreground = "#b1bac4"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff7b72"
     foreground = "#c9d1d9"

--- a/themes/base16-primer-light.dunstrc
+++ b/themes/base16-primer-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#2f363d"
 separator_color = "#2f363d"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e1e4e8"
     foreground = "#959da5"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d1d5da"
     foreground = "#2f363d"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d73a49"
     foreground = "#24292e"

--- a/themes/base16-purpledream.dunstrc
+++ b/themes/base16-purpledream.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#ddd0dd"
 separator_color = "#ddd0dd"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#302030"
     foreground = "#605060"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#403040"
     foreground = "#ddd0dd"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff1d0d"
     foreground = "#eee0ee"

--- a/themes/base16-qualia.dunstrc
+++ b/themes/base16-qualia.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c0c0c0"
 separator_color = "#c0c0c0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#454545"
     foreground = "#454545"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#454545"
     foreground = "#c0c0c0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#efa6a2"
     foreground = "#c0c0c0"

--- a/themes/base16-railscasts.dunstrc
+++ b/themes/base16-railscasts.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#e6e1dc"
 separator_color = "#e6e1dc"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#272935"
     foreground = "#5a647e"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#3a4055"
     foreground = "#e6e1dc"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#da4939"
     foreground = "#f4f1ed"

--- a/themes/base16-rebecca.dunstrc
+++ b/themes/base16-rebecca.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#f1eff8"
 separator_color = "#f1eff8"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#663399"
     foreground = "#666699"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#383a62"
     foreground = "#f1eff8"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#a0a0c5"
     foreground = "#ccccff"

--- a/themes/base16-rose-pine-dawn.dunstrc
+++ b/themes/base16-rose-pine-dawn.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#575279"
 separator_color = "#575279"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#fffaf3"
     foreground = "#9893a5"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#f2e9de"
     foreground = "#575279"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#b4637a"
     foreground = "#575279"

--- a/themes/base16-rose-pine-moon.dunstrc
+++ b/themes/base16-rose-pine-moon.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#e0def4"
 separator_color = "#e0def4"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2a273f"
     foreground = "#6e6a86"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#393552"
     foreground = "#e0def4"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#eb6f92"
     foreground = "#e0def4"

--- a/themes/base16-rose-pine.dunstrc
+++ b/themes/base16-rose-pine.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#e0def4"
 separator_color = "#e0def4"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1f1d2e"
     foreground = "#6e6a86"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#26233a"
     foreground = "#e0def4"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#eb6f92"
     foreground = "#e0def4"

--- a/themes/base16-sagelight.dunstrc
+++ b/themes/base16-sagelight.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#383838"
 separator_color = "#383838"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e8e8e8"
     foreground = "#b8b8b8"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d8d8d8"
     foreground = "#383838"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fa8480"
     foreground = "#282828"

--- a/themes/base16-sakura.dunstrc
+++ b/themes/base16-sakura.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#564448"
 separator_color = "#564448"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#f8e2e7"
     foreground = "#755f64"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#e0ccd1"
     foreground = "#564448"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#df2d52"
     foreground = "#42383a"

--- a/themes/base16-sandcastle.dunstrc
+++ b/themes/base16-sandcastle.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a89984"
 separator_color = "#a89984"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2c323b"
     foreground = "#665c54"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#3e4451"
     foreground = "#a89984"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#83a598"
     foreground = "#d5c4a1"

--- a/themes/base16-selenized-black.dunstrc
+++ b/themes/base16-selenized-black.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#b9b9b9"
 separator_color = "#b9b9b9"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#252525"
     foreground = "#777777"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#3b3b3b"
     foreground = "#b9b9b9"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ed4a46"
     foreground = "#dedede"

--- a/themes/base16-selenized-dark.dunstrc
+++ b/themes/base16-selenized-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#adbcbc"
 separator_color = "#adbcbc"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#184956"
     foreground = "#72898f"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#2d5b69"
     foreground = "#adbcbc"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fa5750"
     foreground = "#cad8d9"

--- a/themes/base16-selenized-light.dunstrc
+++ b/themes/base16-selenized-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#53676d"
 separator_color = "#53676d"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#ece3cc"
     foreground = "#909995"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d5cdb6"
     foreground = "#53676d"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#cc1729"
     foreground = "#3a4d53"

--- a/themes/base16-selenized-white.dunstrc
+++ b/themes/base16-selenized-white.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#474747"
 separator_color = "#474747"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#ebebeb"
     foreground = "#878787"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#cdcdcd"
     foreground = "#474747"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#bf0000"
     foreground = "#282828"

--- a/themes/base16-seti.dunstrc
+++ b/themes/base16-seti.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d6d6d6"
 separator_color = "#d6d6d6"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#282a2b"
     foreground = "#41535b"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#3b758c"
     foreground = "#d6d6d6"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#cd3f45"
     foreground = "#eeeeee"

--- a/themes/base16-shades-of-purple.dunstrc
+++ b/themes/base16-shades-of-purple.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c7c7c7"
 separator_color = "#c7c7c7"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#43d426"
     foreground = "#808080"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#f1d000"
     foreground = "#c7c7c7"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d90429"
     foreground = "#ff77ff"

--- a/themes/base16-shadesmear-dark.dunstrc
+++ b/themes/base16-shadesmear-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#dbdbdb"
 separator_color = "#dbdbdb"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1c1c1c"
     foreground = "#c0c0c0"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#4e4e4e"
     foreground = "#dbdbdb"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#cc5450"
     foreground = "#e4e4e4"

--- a/themes/base16-shadesmear-light.dunstrc
+++ b/themes/base16-shadesmear-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#232323"
 separator_color = "#232323"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e4e4e4"
     foreground = "#4e4e4e"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#c0c0c0"
     foreground = "#232323"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#cc5450"
     foreground = "#1c1c1c"

--- a/themes/base16-shapeshifter.dunstrc
+++ b/themes/base16-shapeshifter.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#102015"
 separator_color = "#102015"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e0e0e0"
     foreground = "#555555"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#ababab"
     foreground = "#102015"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e92f2f"
     foreground = "#040404"

--- a/themes/base16-silk-dark.dunstrc
+++ b/themes/base16-silk-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c7dbdd"
 separator_color = "#c7dbdd"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1d494e"
     foreground = "#587073"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#2a5054"
     foreground = "#c7dbdd"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fb6953"
     foreground = "#cbf2f7"

--- a/themes/base16-silk-light.dunstrc
+++ b/themes/base16-silk-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#385156"
 separator_color = "#385156"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#ccd4d3"
     foreground = "#5c787b"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#90b7b6"
     foreground = "#385156"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#cf432e"
     foreground = "#0e3c46"

--- a/themes/base16-snazzy.dunstrc
+++ b/themes/base16-snazzy.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#e2e4e5"
 separator_color = "#e2e4e5"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#34353e"
     foreground = "#78787e"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#43454f"
     foreground = "#e2e4e5"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff5c57"
     foreground = "#eff0eb"

--- a/themes/base16-solarflare-light.dunstrc
+++ b/themes/base16-solarflare-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#586875"
 separator_color = "#586875"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e8e9ed"
     foreground = "#85939e"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#a6afb8"
     foreground = "#586875"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ef5253"
     foreground = "#222e38"

--- a/themes/base16-solarflare.dunstrc
+++ b/themes/base16-solarflare.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a6afb8"
 separator_color = "#a6afb8"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#222e38"
     foreground = "#667581"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#586875"
     foreground = "#a6afb8"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ef5253"
     foreground = "#e8e9ed"

--- a/themes/base16-solarized-dark.dunstrc
+++ b/themes/base16-solarized-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#93a1a1"
 separator_color = "#93a1a1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#073642"
     foreground = "#657b83"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#586e75"
     foreground = "#93a1a1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#dc322f"
     foreground = "#eee8d5"

--- a/themes/base16-solarized-light.dunstrc
+++ b/themes/base16-solarized-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#586e75"
 separator_color = "#586e75"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#eee8d5"
     foreground = "#839496"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#93a1a1"
     foreground = "#586e75"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#dc322f"
     foreground = "#073642"

--- a/themes/base16-spaceduck.dunstrc
+++ b/themes/base16-spaceduck.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#ecf0c1"
 separator_color = "#ecf0c1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1b1c36"
     foreground = "#686f9a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#30365f"
     foreground = "#ecf0c1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e33400"
     foreground = "#c1c3cc"

--- a/themes/base16-spacemacs.dunstrc
+++ b/themes/base16-spacemacs.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a3a3a3"
 separator_color = "#a3a3a3"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#282828"
     foreground = "#585858"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#444155"
     foreground = "#a3a3a3"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f2241f"
     foreground = "#e8e8e8"

--- a/themes/base16-standardized-dark.dunstrc
+++ b/themes/base16-standardized-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c0c0c0"
 separator_color = "#c0c0c0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#303030"
     foreground = "#898989"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#555555"
     foreground = "#c0c0c0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e15d67"
     foreground = "#e0e0e0"

--- a/themes/base16-standardized-light.dunstrc
+++ b/themes/base16-standardized-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#444444"
 separator_color = "#444444"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#eeeeee"
     foreground = "#767676"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#cccccc"
     foreground = "#444444"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d03e3e"
     foreground = "#333333"

--- a/themes/base16-stella.dunstrc
+++ b/themes/base16-stella.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#998bad"
 separator_color = "#998bad"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#362b48"
     foreground = "#655978"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#4d4160"
     foreground = "#998bad"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c79987"
     foreground = "#b4a5c8"

--- a/themes/base16-still-alive.dunstrc
+++ b/themes/base16-still-alive.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d80000"
 separator_color = "#d80000"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#f0d848"
     foreground = "#f01818"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#fff018"
     foreground = "#d80000"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#487830"
     foreground = "#489000"

--- a/themes/base16-summercamp.dunstrc
+++ b/themes/base16-summercamp.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#736e55"
 separator_color = "#736e55"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2a261c"
     foreground = "#504b38"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#3a3527"
     foreground = "#736e55"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e35142"
     foreground = "#bab696"

--- a/themes/base16-summerfruit-dark.dunstrc
+++ b/themes/base16-summerfruit-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d0d0d0"
 separator_color = "#d0d0d0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#202020"
     foreground = "#505050"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#303030"
     foreground = "#d0d0d0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff0086"
     foreground = "#e0e0e0"

--- a/themes/base16-summerfruit-light.dunstrc
+++ b/themes/base16-summerfruit-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#101010"
 separator_color = "#101010"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e0e0e0"
     foreground = "#b0b0b0"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d0d0d0"
     foreground = "#101010"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff0086"
     foreground = "#151515"

--- a/themes/base16-synth-midnight-dark.dunstrc
+++ b/themes/base16-synth-midnight-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c1c3c4"
 separator_color = "#c1c3c4"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1a1b1c"
     foreground = "#474849"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#28292a"
     foreground = "#c1c3c4"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#b53b50"
     foreground = "#cfd1d2"

--- a/themes/base16-synth-midnight-light.dunstrc
+++ b/themes/base16-synth-midnight-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#28292a"
 separator_color = "#28292a"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#cfd1d2"
     foreground = "#a3a5a6"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#c1c3c4"
     foreground = "#28292a"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#b53b50"
     foreground = "#1a1b1c"

--- a/themes/base16-tango.dunstrc
+++ b/themes/base16-tango.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d3d7cf"
 separator_color = "#d3d7cf"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#8ae234"
     foreground = "#555753"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#fce94f"
     foreground = "#d3d7cf"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#cc0000"
     foreground = "#ad7fa8"

--- a/themes/base16-tender.dunstrc
+++ b/themes/base16-tender.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#eeeeee"
 separator_color = "#eeeeee"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#383838"
     foreground = "#4c4c4c"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#484848"
     foreground = "#eeeeee"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f43753"
     foreground = "#e8e8e8"

--- a/themes/base16-tokyo-city-dark.dunstrc
+++ b/themes/base16-tokyo-city-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d8e2ec"
 separator_color = "#d8e2ec"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1d252c"
     foreground = "#526270"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#28323a"
     foreground = "#d8e2ec"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f7768e"
     foreground = "#f6f6f8"

--- a/themes/base16-tokyo-city-light.dunstrc
+++ b/themes/base16-tokyo-city-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#343b59"
 separator_color = "#343b59"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#f6f6f8"
     foreground = "#9699a3"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#edeff6"
     foreground = "#343b59"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#8c4351"
     foreground = "#1d252c"

--- a/themes/base16-tokyo-city-terminal-dark.dunstrc
+++ b/themes/base16-tokyo-city-terminal-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d8e2ec"
 separator_color = "#d8e2ec"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1d252c"
     foreground = "#526270"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#28323a"
     foreground = "#d8e2ec"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d95468"
     foreground = "#f6f6f8"

--- a/themes/base16-tokyo-city-terminal-light.dunstrc
+++ b/themes/base16-tokyo-city-terminal-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#28323a"
 separator_color = "#28323a"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#f6f6f8"
     foreground = "#b7c5d3"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d8e2ec"
     foreground = "#28323a"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#8c4351"
     foreground = "#1d252c"

--- a/themes/base16-tokyo-night-dark.dunstrc
+++ b/themes/base16-tokyo-night-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a9b1d6"
 separator_color = "#a9b1d6"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#16161e"
     foreground = "#444b6a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#2f3549"
     foreground = "#a9b1d6"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c0caf5"
     foreground = "#cbccd1"

--- a/themes/base16-tokyo-night-light.dunstrc
+++ b/themes/base16-tokyo-night-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#343b59"
 separator_color = "#343b59"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#cbccd1"
     foreground = "#9699a3"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#dfe0e5"
     foreground = "#343b59"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#343b58"
     foreground = "#1a1b26"

--- a/themes/base16-tokyo-night-storm.dunstrc
+++ b/themes/base16-tokyo-night-storm.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a9b1d6"
 separator_color = "#a9b1d6"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#16161e"
     foreground = "#444b6a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#343a52"
     foreground = "#a9b1d6"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c0caf5"
     foreground = "#cbccd1"

--- a/themes/base16-tokyo-night-terminal-dark.dunstrc
+++ b/themes/base16-tokyo-night-terminal-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#787c99"
 separator_color = "#787c99"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1a1b26"
     foreground = "#444b6a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#2f3549"
     foreground = "#787c99"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f7768e"
     foreground = "#cbccd1"

--- a/themes/base16-tokyo-night-terminal-light.dunstrc
+++ b/themes/base16-tokyo-night-terminal-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#4c505e"
 separator_color = "#4c505e"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#cbccd1"
     foreground = "#9699a3"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#dfe0e5"
     foreground = "#4c505e"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#8c4351"
     foreground = "#1a1b26"

--- a/themes/base16-tokyo-night-terminal-storm.dunstrc
+++ b/themes/base16-tokyo-night-terminal-storm.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#787c99"
 separator_color = "#787c99"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1a1b26"
     foreground = "#444b6a"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#343a52"
     foreground = "#787c99"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f7768e"
     foreground = "#cbccd1"

--- a/themes/base16-tokyodark-terminal.dunstrc
+++ b/themes/base16-tokyodark-terminal.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a0a8cd"
 separator_color = "#a0a8cd"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1a1b2a"
     foreground = "#282c34"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#212234"
     foreground = "#a0a8cd"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ee6d85"
     foreground = "#a0a8cd"

--- a/themes/base16-tokyodark.dunstrc
+++ b/themes/base16-tokyodark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#abb2bf"
 separator_color = "#abb2bf"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#151621"
     foreground = "#393a45"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#43444f"
     foreground = "#abb2bf"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#a485dd"
     foreground = "#555661"

--- a/themes/base16-tomorrow-night-eighties.dunstrc
+++ b/themes/base16-tomorrow-night-eighties.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cccccc"
 separator_color = "#cccccc"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#393939"
     foreground = "#999999"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#515151"
     foreground = "#cccccc"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#f2777a"
     foreground = "#e0e0e0"

--- a/themes/base16-tomorrow-night.dunstrc
+++ b/themes/base16-tomorrow-night.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c5c8c6"
 separator_color = "#c5c8c6"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#282a2e"
     foreground = "#969896"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#373b41"
     foreground = "#c5c8c6"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#cc6666"
     foreground = "#e0e0e0"

--- a/themes/base16-tomorrow.dunstrc
+++ b/themes/base16-tomorrow.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#4d4d4c"
 separator_color = "#4d4d4c"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e0e0e0"
     foreground = "#8e908c"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d6d6d6"
     foreground = "#4d4d4c"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c82829"
     foreground = "#282a2e"

--- a/themes/base16-tube.dunstrc
+++ b/themes/base16-tube.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#d9d8d8"
 separator_color = "#d9d8d8"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1c3f95"
     foreground = "#737171"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#5a5758"
     foreground = "#d9d8d8"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ee2e24"
     foreground = "#e7e7e8"

--- a/themes/base16-twilight.dunstrc
+++ b/themes/base16-twilight.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a7a7a7"
 separator_color = "#a7a7a7"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#323537"
     foreground = "#5f5a60"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#464b50"
     foreground = "#a7a7a7"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#cf6a4c"
     foreground = "#c3c3c3"

--- a/themes/base16-unikitty-dark.dunstrc
+++ b/themes/base16-unikitty-dark.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#bcbabe"
 separator_color = "#bcbabe"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#4a464d"
     foreground = "#838085"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#666369"
     foreground = "#bcbabe"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d8137f"
     foreground = "#d8d7da"

--- a/themes/base16-unikitty-light.dunstrc
+++ b/themes/base16-unikitty-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#6c696e"
 separator_color = "#6c696e"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e1e1e2"
     foreground = "#a7a5a8"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#c4c3c5"
     foreground = "#6c696e"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d8137f"
     foreground = "#4f4b51"

--- a/themes/base16-unikitty-reversible.dunstrc
+++ b/themes/base16-unikitty-reversible.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c3c2c4"
 separator_color = "#c3c2c4"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#4b484e"
     foreground = "#878589"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#69666b"
     foreground = "#c3c2c4"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d8137f"
     foreground = "#e1e0e1"

--- a/themes/base16-uwunicorn.dunstrc
+++ b/themes/base16-uwunicorn.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#eed5d9"
 separator_color = "#eed5d9"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2f2a3f"
     foreground = "#6c3cb2"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#46354a"
     foreground = "#eed5d9"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#877bb6"
     foreground = "#d9c2c6"

--- a/themes/base16-vice.dunstrc
+++ b/themes/base16-vice.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#8b9cbe"
 separator_color = "#8b9cbe"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#22262d"
     foreground = "#383a47"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#3c3f4c"
     foreground = "#8b9cbe"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff29a8"
     foreground = "#b2bfd9"

--- a/themes/base16-vulcan.dunstrc
+++ b/themes/base16-vulcan.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#5b778c"
 separator_color = "#5b778c"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#122339"
     foreground = "#7a5759"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#003552"
     foreground = "#5b778c"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#818591"
     foreground = "#333238"

--- a/themes/base16-windows-10-light.dunstrc
+++ b/themes/base16-windows-10-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#767676"
 separator_color = "#767676"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e5e5e5"
     foreground = "#cccccc"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d9d9d9"
     foreground = "#767676"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#c50f1f"
     foreground = "#414141"

--- a/themes/base16-windows-10.dunstrc
+++ b/themes/base16-windows-10.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cccccc"
 separator_color = "#cccccc"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2f2f2f"
     foreground = "#767676"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#535353"
     foreground = "#cccccc"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#e74856"
     foreground = "#dfdfdf"

--- a/themes/base16-windows-95-light.dunstrc
+++ b/themes/base16-windows-95-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#545454"
 separator_color = "#545454"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e0e0e0"
     foreground = "#a8a8a8"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#c4c4c4"
     foreground = "#545454"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#a80000"
     foreground = "#2a2a2a"

--- a/themes/base16-windows-95.dunstrc
+++ b/themes/base16-windows-95.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#a8a8a8"
 separator_color = "#a8a8a8"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1c1c1c"
     foreground = "#545454"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#383838"
     foreground = "#a8a8a8"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fc5454"
     foreground = "#d2d2d2"

--- a/themes/base16-windows-highcontrast-light.dunstrc
+++ b/themes/base16-windows-highcontrast-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#545454"
 separator_color = "#545454"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#e8e8e8"
     foreground = "#c0c0c0"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d4d4d4"
     foreground = "#545454"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#800000"
     foreground = "#2a2a2a"

--- a/themes/base16-windows-highcontrast.dunstrc
+++ b/themes/base16-windows-highcontrast.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c0c0c0"
 separator_color = "#c0c0c0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#1c1c1c"
     foreground = "#545454"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#383838"
     foreground = "#c0c0c0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#fc5454"
     foreground = "#dedede"

--- a/themes/base16-windows-nt-light.dunstrc
+++ b/themes/base16-windows-nt-light.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#808080"
 separator_color = "#808080"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#eaeaea"
     foreground = "#c0c0c0"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#d5d5d5"
     foreground = "#808080"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#800000"
     foreground = "#404040"

--- a/themes/base16-windows-nt.dunstrc
+++ b/themes/base16-windows-nt.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#c0c0c0"
 separator_color = "#c0c0c0"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#2a2a2a"
     foreground = "#808080"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#555555"
     foreground = "#c0c0c0"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#ff0000"
     foreground = "#e0e0e0"

--- a/themes/base16-woodland.dunstrc
+++ b/themes/base16-woodland.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#cabcb1"
 separator_color = "#cabcb1"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#302b25"
     foreground = "#9d8b70"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#48413a"
     foreground = "#cabcb1"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#d35c5c"
     foreground = "#d7c8bc"

--- a/themes/base16-xcode-dusk.dunstrc
+++ b/themes/base16-xcode-dusk.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#939599"
 separator_color = "#939599"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#3d4048"
     foreground = "#686a71"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#53555d"
     foreground = "#939599"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#b21889"
     foreground = "#a9aaae"

--- a/themes/base16-zenbones.dunstrc
+++ b/themes/base16-zenbones.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#b279a7"
 separator_color = "#b279a7"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#de6e7c"
     foreground = "#b77e64"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#819b69"
     foreground = "#b279a7"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#3d3839"
     foreground = "#66a5ad"

--- a/themes/base16-zenburn.dunstrc
+++ b/themes/base16-zenburn.dunstrc
@@ -3,16 +3,16 @@ frame_color = "#dcdccc"
 separator_color = "#dcdccc"
 
 [base16_low]
-    msg_urgency = low
+    msg_urgency = "low"
     background = "#404040"
     foreground = "#6f6f6f"
 
 [base16_normal]
-    msg_urgency = normal
+    msg_urgency = "normal"
     background = "#606060"
     foreground = "#dcdccc"
 
 [base16_critical]
-    msg_urgency = critical
+    msg_urgency = "critical"
     background = "#dca3a3"
     foreground = "#c0c0c0"


### PR DESCRIPTION
Hi,

I have been using base16-dunst for a while, on NixOS with home-manager. NixOS and home-manager allow me to configure my system and home directory using a special functional programming language.

Up until now I have been using base16-dunst with home-manager using a little hack. Dunst itself can be configured using an AttributeSet in the nix language, nix also has a `builtins.fromTOML` function, which reads TOML and returns an AttributeSet. However, the base16-dunst configuration does not have a valid TOML, because of the following lines:

```toml
[base16_low|normal|critical]
    msg_ugrency = low|normal|critical
```

Because of this reason, I have been using a hack (https://github.com/nix-community/home-manager/pull/4260), where I just append the base16-dunst config to the config generated by my home-manager configuration. However, a better solution would be to merge the base16-dunst config together with my home-manager config using `builtins.fromTOML`. Quoting `msg_urgency` would be already enough and dunst can also correctly parse the quoted `msg_urgency`.

Would this change break something I am not aware of?