### PR TITLE
Use shared actions for weekly builds and to auto assign for issues

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,0 +1,11 @@
+name: "Auto assignment for issues"
+
+on:
+  issues:
+    types: ["opened"]
+
+jobs:
+  auto-assign:
+    uses: "tinted-theming/home/.github/workflows/shared-auto-assign-issues.yml@main"
+    secrets:
+      token: ${{ secrets.BOT_ACCESS_TOKEN }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,25 +1,13 @@
-name: Update with the latest colorschemes
+name: Update with the latest tinted-theming colorschemes
 on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 0" # https://crontab.guru/every-week
 
 jobs:
-  run:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fetch the repository code
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.BOT_ACCESS_TOKEN }}
-      - name: Update schemes
-        uses: tinted-theming/tinted-builder-rust@latest
-      - name: Commit the changes, if any
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Update with the latest tinted-theming colorschemes
-          branch: ${{ github.head_ref }}
-          commit_user_name: tinted-theming-bot
-          commit_user_email: tintedtheming@proton.me
-          commit_author: tinted-theming-bot <tintedtheming@proton.me>
-
+  build-and-commit:
+    uses: "tinted-theming/home/.github/workflows/shared-build-template-and-commit-themes.yml@main"
+    secrets:
+      token: ${{ secrets.BOT_ACCESS_TOKEN }}
+    with:
+      ref: ${{ github.head_ref }}


### PR DESCRIPTION
- Use https://github.com/tinted-theming/home/blob/main/.github/workflows/shared-auto-assign-issues.yml to auto assign maintainers in `.github/CODEOWNERS` file to issue when created.
- Use shared action for weekly builds: https://github.com/tinted-theming/home/blob/main/.github/workflows/shared-build-template-and-commit-themes.yml